### PR TITLE
fix lazy-loaded wallet state

### DIFF
--- a/packages/wallets/evm/src/evm.ts
+++ b/packages/wallets/evm/src/evm.ts
@@ -450,7 +450,7 @@ export abstract class EVMWallet<COpts = unknown> extends Wallet<
 
   getWalletState(): WalletState {
     // If connector hasn't been created yet, it's not detected
-    if (!this.connector) {
+    if (!this.connector && !this.connectorFn) {
       return WalletState.NotDetected;
     }
 


### PR DESCRIPTION
if a wallet has a `connectorFn`, it is loadable. this was changed in https://github.com/wormholelabs-xyz/wallet-aggregator-sdk/pull/2 and I didn't realize `getWalletState()` needed to change for lazy-loaded wallets.