### PR TITLE
refactor: make wallet events more permissive

### DIFF
--- a/packages/wallets/evm/package.json
+++ b/packages/wallets/evm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wormhole-labs/wallet-aggregator-evm",
   "repository": "https://github.com/wormholelabs-xyz/wallet-aggregator-sdk/tree/master/packages/wallets/evm",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/wallets/evm/src/evm.ts
+++ b/packages/wallets/evm/src/evm.ts
@@ -124,8 +124,7 @@ export abstract class EVMWallet<COpts = unknown> extends Wallet<
   EthereumMessage,
   Signature,
   EVMNetworkInfo,
-  BaseFeatures,
-  EVMWalletEvents
+  BaseFeatures
 > {
   protected chains: readonly [Chain, ...Chain[]];
   protected connector!: Connector;

--- a/packages/wallets/sui/package.json
+++ b/packages/wallets/sui/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wormhole-labs/wallet-aggregator-sui",
   "repository": "https://github.com/wormholelabs-xyz/wallet-aggregator-sdk/tree/master/packages/wallets/sui",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",

--- a/packages/wallets/sui/src/sui.ts
+++ b/packages/wallets/sui/src/sui.ts
@@ -72,8 +72,7 @@ export class SuiWallet extends Wallet<
   SuiSignMessageInput,
   SuiSignMessageOutput,
   SuiNetworkInfo,
-  BaseFeatures,
-  WalletEvents
+  BaseFeatures
 > {
   private readonly _name;
   private accounts: WalletAccount[] = [];


### PR DESCRIPTION
Avoids having to create a wallet aggregator adapter class in Connect to wrap the aggregator Wallets, because the events on Connect's Wallet interface may not match those on the aggregator Wallets exactly.