### PR TITLE
feat: add Plume network support

### DIFF
--- a/packages/wallets/evm/src/chains.ts
+++ b/packages/wallets/evm/src/chains.ts
@@ -432,6 +432,27 @@ export const XRPLEVM = {
   testnet: false,
 } as const satisfies Chain;
 
+export const PLUME = {
+  id: 98866,
+  name: "Plume",
+  nativeCurrency: { name: "Plume", symbol: "PLUME", decimals: 18 },
+  rpcUrls: {
+    default: {
+      http: ["https://rpc.plume.org"],
+    },
+    public: {
+      http: ["https://rpc.plume.org"],
+    },
+  },
+  blockExplorers: {
+    default: {
+      name: "Plume Explorer",
+      url: "https://explorer.plume.org/",
+    },
+  },
+  testnet: false,
+} as const satisfies Chain;
+
 export const HYPER_EVM = {
   id: 999,
   name: "HyperEVM",
@@ -478,5 +499,6 @@ export const DEFAULT_CHAINS = [
   MEZO_TESTNET,
   XRPLEVM,
   XRPLEVM_TESTNET,
+  PLUME,
   HYPER_EVM,
 ] as const satisfies readonly Chain[];


### PR DESCRIPTION
## Summary
- Added Plume mainnet configuration to EVM chains
- Chain ID: 98866
- Native currency: PLUME
- RPC: https://rpc.plume.org
- Explorer: https://explorer.plume.org/