### PR TITLE
chore: release wallet-aggregator-evm 0.9.2

### DIFF
--- a/packages/wallets/evm/package.json
+++ b/packages/wallets/evm/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@wormhole-labs/wallet-aggregator-evm",
   "repository": "https://github.com/wormholelabs-xyz/wallet-aggregator-sdk/tree/master/packages/wallets/evm",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "license": "MIT",
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",


### PR DESCRIPTION
## Summary
- Released @wormhole-labs/wallet-aggregator-evm version 0.9.2
- Includes Plume network support (Chain ID: 98866)
- Published to npm registry