### PR TITLE
Add trusted publishing and supply chain security

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,34 @@
+name: Verify Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build the project
+        run: pnpm run build

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Publish to NPM
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to publish"
+        required: true
+        type: "string"
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 20
+          cache: "pnpm"
+          registry-url: "https://registry.npmjs.org"
+      - run: pnpm install --frozen-lockfile
+      - run: |
+          # Update the version in all package.json files
+          pnpm run version ${{ inputs.version }}
+      - run: pnpm run build
+      - run: |
+          VERSION="${{ inputs.version }}"
+
+          if [[ $VERSION == *"beta"* ]]; then
+            tag=beta
+          elif [[ $VERSION == *"alpha"* ]]; then
+            tag=alpha
+          else
+            tag=latest
+          fi
+
+          pnpm publish -r --access public --tag $tag --no-git-checks
+
+        env:
+          VERSION: ${{ inputs.version }}


### PR DESCRIPTION
## Changes

- Adds supply chain security with 24-hour package delay (`minimum-release-age=1440`)
- Configures npm trusted publishing with OIDC authentication
- Adds GitHub Actions workflows for build and publish
- Excludes internal `@wormhole-foundation/*` and `@wormhole-labs/*` packages from delay

## Security Improvements

- **Supply Chain Protection**: Blocks installing packages published within last 24 hours, protecting against malware injection
- **No More Long-Lived Tokens**: OIDC authentication replaces `NPM_TOKEN` secret
- **Automatic Provenance**: Cryptographic proof of package origin via trusted publishing

## Workflows Added

- **build.yml**: Runs on push/PR to verify builds pass
- **publish.yml**: Manual workflow for publishing all packages with OIDC

## Configuration Required

For each of the 14 packages, configure trusted publisher on npmjs.com:
- Organization: `wormholelabs-xyz`
- Repository: `wallet-aggregator-sdk`
- Workflow: `publish.yml`
- Environment: *leave blank*

Packages to configure:
- @wormhole-labs/wallet-aggregator-algorand
- @wormhole-labs/wallet-aggregator-aptos
- @wormhole-labs/wallet-aggregator-core
- @wormhole-labs/wallet-aggregator-cosmos
- @wormhole-labs/wallet-aggregator-cosmos-evm
- @wormhole-labs/wallet-aggregator-evm
- @wormhole-labs/wallet-aggregator-injective
- @wormhole-labs/wallet-aggregator-near
- @wormhole-labs/wallet-aggregator-react
- @wormhole-labs/wallet-aggregator-sei
- @wormhole-labs/wallet-aggregator-solana
- @wormhole-labs/wallet-aggregator-sui
- @wormhole-labs/wallet-aggregator-terra
- @wormhole-labs/wallet-aggregator-xpla