### PR TITLE
fix: address zizmor security findings

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,10 +11,14 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - name: Checkout code
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        with:
+          persist-credentials: false
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,6 +13,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+        with:
+          persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.1


### PR DESCRIPTION
## Summary

Fixes the following zizmor security findings in GitHub Actions workflow files:

- **artipacked** (`.github/workflows/build.yml`): Added `persist-credentials: false` to `actions/checkout` step to prevent credential persistence through artifacts.
- **excessive-permissions** (`.github/workflows/build.yml`): Added explicit `permissions: contents: read` block to the `build` job to narrow default overly-broad permissions.
- **artipacked** (`.github/workflows/publish.yml`): Added `persist-credentials: false` to `actions/checkout` step to prevent credential persistence through artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)