### PR TITLE
feat: migrate Sui wallet to @mysten/sui v2 (gRPC) and ESM-only

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -75,7 +75,7 @@
     },
     "packages/wallets/btc": {
       "name": "@wormhole-labs/wallet-aggregator-btc",
-      "version": "0.0.0-auto-managed",
+      "version": "0.0.1-beta.0",
       "dependencies": {
         "@wormhole-labs/wallet-aggregator-core": "workspace:^",
       },
@@ -255,9 +255,9 @@
       "name": "@wormhole-labs/wallet-aggregator-sui",
       "version": "0.0.0-auto-managed",
       "dependencies": {
-        "@kunalabs-io/sui-snap-wallet": "^0.4.2",
-        "@mysten/sui.js": "0.32.2",
-        "@mysten/wallet-standard": "0.5.4",
+        "@kunalabs-io/sui-snap-wallet": "^0.5.0",
+        "@mysten/sui": "^2.17.0",
+        "@mysten/wallet-standard": "^0.20.3",
         "@wormhole-labs/wallet-aggregator-core": "workspace:^",
       },
       "devDependencies": {
@@ -621,7 +621,7 @@
 
     "@keystonehq/sol-keyring": ["@keystonehq/sol-keyring@0.20.0", "", { "dependencies": { "@keystonehq/bc-ur-registry": "0.5.4", "@keystonehq/bc-ur-registry-sol": "^0.9.2", "@keystonehq/sdk": "^0.19.2", "@solana/web3.js": "^1.36.0", "bs58": "^5.0.0", "uuid": "^8.3.2" } }, "sha512-UBeMlecybTDQaFMI951LBEVRyZarqKHOcwWqqvphV+x7WquYz0SZ/wf/PhizV0MWoGTQwt2m5aqROzksi6svqw=="],
 
-    "@kunalabs-io/sui-snap-wallet": ["@kunalabs-io/sui-snap-wallet@0.4.4", "", { "dependencies": { "@metamask/detect-provider": "^2.0.0", "@metamask/providers": "^22.1.0", "@mysten/sui.js": "^0.50.1", "@mysten/wallet-adapter-base": "^0.9.0", "@mysten/wallet-standard": "^0.10.3", "superstruct": "^2.0.2" } }, "sha512-EjdMbS4gJ+8KkcFrSBW0tCgnCWOOWXfvLR4WNzEapa/hc5VG86FlEjz46s+QPoPXrae4u/R4Y8t495L0Fgn5qw=="],
+    "@kunalabs-io/sui-snap-wallet": ["@kunalabs-io/sui-snap-wallet@0.5.0", "", { "dependencies": { "@metamask/detect-provider": "^2.0.0", "@metamask/providers": "^22.1.1", "@mysten/sui": "^2.17.0", "@mysten/wallet-standard": "^0.20.3", "superstruct": "^2.0.2" } }, "sha512-W6roel45A81gqr7YdSZlIVEXUzg8W6PK8W8fesiL3+/NWj8KFxcUT2c9hJOZhUyvgS3azl0BYiWu0VASat2VZg=="],
 
     "@ledgerhq/cryptoassets": ["@ledgerhq/cryptoassets@9.13.0", "", { "dependencies": { "invariant": "2" } }, "sha512-MzGJyc48OGU/FLYGYwEJyfOgbJzlR8XJ9Oo6XpNpNUM1/E5NDqvD72V0D+0uWIJYN3e2NtyqHXShLZDu7P95YA=="],
 
@@ -719,13 +719,13 @@
 
     "@msgpack/msgpack": ["@msgpack/msgpack@3.1.2", "", {}, "sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ=="],
 
-    "@mysten/bcs": ["@mysten/bcs@0.7.1", "", { "dependencies": { "bs58": "^5.0.0" } }, "sha512-wFPb8bkhwrbiStfZMV5rFM7J+umpke59/dNjDp+UYJKykNlW23LCk2ePyEUvGdb62HGJM1jyOJ8g4egE3OmdKA=="],
+    "@mysten/bcs": ["@mysten/bcs@2.0.5", "", { "dependencies": { "@mysten/utils": "^0.3.3", "@scure/base": "^2.0.0" } }, "sha512-Dop9Xq36DPLlsmIDQZvUg4uJeBBxIGirgp2OXGaEff+mtLKFBoW2HnE3aSTSSpiMQH9XRhjwtiM16zFJhFqz0Q=="],
 
-    "@mysten/sui.js": ["@mysten/sui.js@0.32.2", "", { "dependencies": { "@mysten/bcs": "0.7.1", "@noble/curves": "^1.0.0", "@noble/hashes": "^1.3.0", "@scure/bip32": "^1.3.0", "@scure/bip39": "^1.2.0", "@suchipi/femver": "^1.0.0", "jayson": "^4.0.0", "rpc-websockets": "^7.5.1", "superstruct": "^1.0.3", "tweetnacl": "^1.0.3" } }, "sha512-/Hm4xkGolJhqj8FvQr7QSHDTlxIvL52mtbOao9f75YjrBh7y1Uh9kbJSY7xiTF1NY9sv6p5hUVlYRJuM0Hvn9A=="],
+    "@mysten/sui": ["@mysten/sui@2.17.0", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@mysten/bcs": "^2.0.5", "@mysten/utils": "^0.3.3", "@noble/curves": "^2.0.1", "@noble/hashes": "^2.0.1", "@protobuf-ts/grpcweb-transport": "^2.11.1", "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1", "@scure/base": "^2.0.0", "@scure/bip32": "^2.0.1", "@scure/bip39": "^2.0.1", "gql.tada": "^1.9.0", "graphql": "^16.12.0", "poseidon-lite": "0.2.1", "valibot": "^1.2.0" } }, "sha512-TrS1BCPm4V6rC69MBejmcqnKIyJ5t1iksax4XA9jWarZxAAp9LMmdxEBebejyDT/yAJxYIf3fNm5WBkHE2qnIw=="],
 
-    "@mysten/wallet-adapter-base": ["@mysten/wallet-adapter-base@0.9.0", "", { "dependencies": { "@mysten/sui.js": "0.40.0", "@mysten/wallet-standard": "0.6.0" } }, "sha512-Obcfd30AC0Tcyvqc9+h0vvjrRB6Td2PNWhxRlTq/hSxDY66M3XqTLgoO8wDBtz+91oga4obAYvM02m7xV7X0Zw=="],
+    "@mysten/utils": ["@mysten/utils@0.3.3", "", { "dependencies": { "@scure/base": "^2.0.0" } }, "sha512-gVHn5toh24eXXLEyBknwwM2F/tbDgqPX0yj77KtHjuoYUallcQ9vSwGfGsAy39IcTB259Yprt/ZOEwdup+zrpA=="],
 
-    "@mysten/wallet-standard": ["@mysten/wallet-standard@0.5.4", "", { "dependencies": { "@mysten/sui.js": "0.32.2", "@wallet-standard/core": "1.0.3" } }, "sha512-T5lS95iWnoLMrIf3kRArLdlYwLf7dNVRfCThvNQiwHPEG35UOGXzDPNLSX6m5WcMOjFIuToIyCWXqVfq97AC3Q=="],
+    "@mysten/wallet-standard": ["@mysten/wallet-standard@0.20.3", "", { "dependencies": { "@wallet-standard/core": "1.1.1" }, "peerDependencies": { "@mysten/sui": "*" } }, "sha512-Kp1EpWaQAwANuMoTCJKVdZnEOaE9aJ5PPvIC7qg+J3u6Uf20VsVsQngZllyaS2OQHm+iLlJzcLXHff7ttvQJYw=="],
 
     "@near-wallet-selector/core": ["@near-wallet-selector/core@7.6.1", "", { "dependencies": { "rxjs": "^7.5.7" }, "peerDependencies": { "near-api-js": "^0.44.2 || ^1.0.0" } }, "sha512-qFBWdtyZYXMBoIc2rTXKqUWE5mnaqo/7oIDn2qExTFRyRiLiGSe5ak0j5MkS52wNeFVu45FOs2NqszrKTiNyig=="],
 
@@ -746,8 +746,6 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
-
-    "@open-rpc/client-js": ["@open-rpc/client-js@1.8.1", "", { "dependencies": { "isomorphic-fetch": "^3.0.0", "isomorphic-ws": "^5.0.0", "strict-event-emitter-types": "^2.0.0", "ws": "^7.0.0" } }, "sha512-vV+Hetl688nY/oWI9IFY0iKDrWuLdYhf7OIKI6U1DcnJV7r4gAgwRJjEr1QVYszUc0gjkHoQJzqevmXMGLyA0g=="],
 
     "@osmonauts/helpers": ["@osmonauts/helpers@0.6.0", "", { "dependencies": { "@babel/runtime": "^7.18.9", "@cosmjs/amino": "0.28.13", "@cosmjs/crypto": "0.28.13", "@cosmjs/proto-signing": "0.28.13", "@cosmjs/stargate": "0.28.13", "cosmjs-types": "0.5.1", "long": "^5.2.0", "protobufjs": "^6.11.3" } }, "sha512-l62tWR/0W4R+5wRvMeRK0zlaJ8WZhULKsQAZ7kNzggL0pbndIAV+0BJ/jEBbNletoeGtuV8rpi6Wo+w+RmtZGw=="],
 
@@ -770,6 +768,12 @@
     "@perawallet/connect": ["@perawallet/connect@1.4.2", "", { "dependencies": { "@evanhahn/lottie-web-light": "5.8.1", "@walletconnect/client": "^1.8.0", "@walletconnect/types": "^1.8.0", "bowser": "2.11.0", "buffer": "^6.0.3", "qr-code-styling": "1.6.0-rc.1" }, "peerDependencies": { "algosdk": "^3.0.0" } }, "sha512-LCdaWMm1PerIxnBWTkPVEfEbEJ+onfIfDK80+Nj//Rce//tLFzGU7kAxSU7Al70hrD1AvnYyXm2svFbsUzOa7w=="],
 
     "@project-serum/sol-wallet-adapter": ["@project-serum/sol-wallet-adapter@0.2.6", "", { "dependencies": { "bs58": "^4.0.1", "eventemitter3": "^4.0.7" }, "peerDependencies": { "@solana/web3.js": "^1.5.0" } }, "sha512-cpIb13aWPW8y4KzkZAPDgw+Kb+DXjCC6rZoH74MGm3I/6e/zKyGnfAuW5olb2zxonFqsYgnv7ev8MQnvSgJ3/g=="],
+
+    "@protobuf-ts/grpcweb-transport": ["@protobuf-ts/grpcweb-transport@2.11.1", "", { "dependencies": { "@protobuf-ts/runtime": "^2.11.1", "@protobuf-ts/runtime-rpc": "^2.11.1" } }, "sha512-1W4utDdvOB+RHMFQ0soL4JdnxjXV+ddeGIUg08DvZrA8Ms6k5NN6GBFU2oHZdTOcJVpPrDJ02RJlqtaoCMNBtw=="],
+
+    "@protobuf-ts/runtime": ["@protobuf-ts/runtime@2.11.1", "", {}, "sha512-KuDaT1IfHkugM2pyz+FwiY80ejWrkH1pAtOBOZFuR6SXEFTsnb/jiQWQ1rCIrcKx2BtyxnxW6BWwsVSA/Ie+WQ=="],
+
+    "@protobuf-ts/runtime-rpc": ["@protobuf-ts/runtime-rpc@2.11.1", "", { "dependencies": { "@protobuf-ts/runtime": "^2.11.1" } }, "sha512-4CqqUmNA+/uMz00+d3CYKgElXO9VrEbucjnBFEjqI4GuDrEQ32MaI3q+9qPBvIGOlL4PmHXrzM32vBPWRhQKWQ=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -1049,8 +1053,6 @@
 
     "@stencil/core": ["@stencil/core@4.38.3", "", { "optionalDependencies": { "@rollup/rollup-darwin-arm64": "4.34.9", "@rollup/rollup-darwin-x64": "4.34.9", "@rollup/rollup-linux-arm64-gnu": "4.34.9", "@rollup/rollup-linux-arm64-musl": "4.34.9", "@rollup/rollup-linux-x64-gnu": "4.34.9", "@rollup/rollup-linux-x64-musl": "4.34.9", "@rollup/rollup-win32-arm64-msvc": "4.34.9", "@rollup/rollup-win32-x64-msvc": "4.34.9" }, "bin": { "stencil": "bin/stencil" } }, "sha512-rSDzGUfi58X8K79ySjlM6KlY+mq7D+ittzgNAdYHcsXHc70sBpdatFhnbOg25uVDiMf7xRAH9slP38pPdXnZOQ=="],
 
-    "@suchipi/femver": ["@suchipi/femver@1.0.0", "", {}, "sha512-bprE8+K5V+DPX7q2e2K57ImqNBdfGHDIWaGI5xHxZoxbKOuQZn4wzPiUxOAHnsUr3w3xHrWXwN7gnG/iIuEMIg=="],
-
     "@swc/helpers": ["@swc/helpers@0.5.17", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-5IKx/Y13RsYd+sauPb2x+U/xZikHjolzfuDgTAl/Tdf3Q8rslRvC19NKDLgAJQ6wsqADk10ntlv08nPFw/gO/A=="],
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
@@ -1244,6 +1246,8 @@
     "@wallet-standard/base": ["@wallet-standard/base@1.1.0", "", {}, "sha512-DJDQhjKmSNVLKWItoKThJS+CsJQjR9AOBOirBVT1F9YpRyC9oYHE+ZnSf8y8bxUphtKqdQMPVQ2mHohYdRvDVQ=="],
 
     "@wallet-standard/core": ["@wallet-standard/core@1.0.3", "", { "dependencies": { "@wallet-standard/app": "^1.0.1", "@wallet-standard/base": "^1.0.1", "@wallet-standard/features": "^1.0.3", "@wallet-standard/wallet": "^1.0.1" } }, "sha512-Jb33IIjC1wM1HoKkYD7xQ6d6PZ8EmMZvyc8R7dFgX66n/xkvksVTW04g9yLvQXrLFbcIjHrCxW6TXMhvpsAAzg=="],
+
+    "@wallet-standard/errors": ["@wallet-standard/errors@0.1.2", "", { "dependencies": { "chalk": "^5.4.1", "commander": "^13.1.0" }, "bin": { "errors": "bin/cli.mjs" } }, "sha512-oEzKUqJefKby6wcIvaJgrSEe/uNn/rnqkJ0P/85K+h0i5Tdo9E3L22VWq/j5K1e8hHMnZd6LgaIr8m/Wn7X/Ng=="],
 
     "@wallet-standard/features": ["@wallet-standard/features@1.1.0", "", { "dependencies": { "@wallet-standard/base": "^1.1.0" } }, "sha512-hiEivWNztx73s+7iLxsuD1sOJ28xtRix58W7Xnz4XzzA/pF0+aicnWgjOdA10doVDEDZdUuZCIIqG96SFNlDUg=="],
 
@@ -1985,8 +1989,6 @@
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
 
-    "isomorphic-fetch": ["isomorphic-fetch@3.0.0", "", { "dependencies": { "node-fetch": "^2.6.1", "whatwg-fetch": "^3.4.1" } }, "sha512-qvUtwJ3j6qwsF3jLxkZ72qCgjMysPzDfeV240JHiGZsANBYd+EEuu35v7dfrJ9Up0Ak07D7GGSkGhCHTqg/5wA=="],
-
     "isomorphic-ws": ["isomorphic-ws@4.0.1", "", { "peerDependencies": { "ws": "*" } }, "sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w=="],
 
     "isows": ["isows@1.0.7", "", { "peerDependencies": { "ws": "*" } }, "sha512-I1fSfDCZL5P0v33sVqeTDSpcstAg/N+wF5HS033mogOVIp4B+oHC7oOCsA3axAbBSGTJ8QubbNmnIRN/h8U7hg=="],
@@ -2469,8 +2471,6 @@
 
     "stream-shift": ["stream-shift@1.0.3", "", {}, "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ=="],
 
-    "strict-event-emitter-types": ["strict-event-emitter-types@2.0.0", "", {}, "sha512-Nk/brWYpD85WlOgzw5h173aci0Teyv8YdIAEtV+N88nDB0dLlazZyJMIsN6eo1/AR61l+p6CJTG1JIyFaoNEEA=="],
-
     "strict-uri-encode": ["strict-uri-encode@2.0.0", "", {}, "sha512-QwiXZgpRcKkhTj2Scnn++4PKtWsH0kpzZ62L2R6c/LUVYv7hVnZqcg2+sMuT6R7Jusu1vviK/MFsu6kNJfWlEQ=="],
 
     "string-argv": ["string-argv@0.3.2", "", {}, "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q=="],
@@ -2595,6 +2595,8 @@
 
     "uuidv4": ["uuidv4@6.2.13", "", { "dependencies": { "@types/uuid": "8.3.4", "uuid": "8.3.2" } }, "sha512-AXyzMjazYB3ovL3q051VLH06Ixj//Knx7QnUSi1T//Ie3io6CpsPu9nVMOx5MoLWh6xV0B9J0hIaxungxXUbPQ=="],
 
+    "valibot": ["valibot@1.4.1", "", { "peerDependencies": { "typescript": ">=5" }, "optionalPeers": ["typescript"] }, "sha512-klCmFTz2jeDluy9RwX+F884TCiogtdBJ/YaxSx1EOBYXa3NXNWj8kR1jjN8rzluwojJVWWaHJ4r1U5LfICnM3g=="],
+
     "valtio": ["valtio@1.11.2", "", { "dependencies": { "proxy-compare": "2.5.1", "use-sync-external-store": "1.2.0" }, "peerDependencies": { "@types/react": ">=16.8", "react": ">=16.8" }, "optionalPeers": ["@types/react", "react"] }, "sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw=="],
 
     "varuint-bitcoin": ["varuint-bitcoin@2.0.0", "", { "dependencies": { "uint8array-tools": "^0.0.8" } }, "sha512-6QZbU/rHO2ZQYpWFDALCDSRsXbAs1VOEmXAxtbtjLtKuMJ/FQ8YbhfxlaiKv5nklci0M6lZtlZyxo9Q+qNnyog=="],
@@ -2614,8 +2616,6 @@
     "webrtc-adapter": ["webrtc-adapter@7.7.1", "", { "dependencies": { "rtcpeerconnection-shim": "^1.2.15", "sdp": "^2.12.0" } }, "sha512-TbrbBmiQBL9n0/5bvDdORc6ZfRY/Z7JnEj+EYOD1ghseZdpJ+nF2yx14k3LgQKc7JZnG7HAcL+zHnY25So9d7A=="],
 
     "websocket": ["websocket@1.0.35", "", { "dependencies": { "bufferutil": "^4.0.1", "debug": "^2.2.0", "es5-ext": "^0.10.63", "typedarray-to-buffer": "^3.1.5", "utf-8-validate": "^5.0.2", "yaeti": "^0.0.6" } }, "sha512-/REy6amwPZl44DDzvRCkaI1q1bIiQB0mEFQLUrhz3z2EK91cp3n72rAjUlrTP0zV22HJIUOVHQGPxhFRjxjt+Q=="],
-
-    "whatwg-fetch": ["whatwg-fetch@3.6.20", "", {}, "sha512-EqhiFU6daOA8kpjOWTL0olhVOF3i7OrFzSYiGsEMB8GcXS+RrzauAERX65xMeNWVqxA6HXH2m69Z9LaKKdisfg=="],
 
     "whatwg-url": ["whatwg-url@5.0.0", "", { "dependencies": { "tr46": "~0.0.3", "webidl-conversions": "^3.0.0" } }, "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw=="],
 
@@ -2817,10 +2817,6 @@
 
     "@keystonehq/sol-keyring/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js": ["@mysten/sui.js@0.50.1", "", { "dependencies": { "@graphql-typed-document-node/core": "^3.2.0", "@mysten/bcs": "0.11.1", "@noble/curves": "^1.1.0", "@noble/hashes": "^1.3.1", "@scure/bip32": "^1.3.1", "@scure/bip39": "^1.2.1", "@suchipi/femver": "^1.0.0", "bech32": "^2.0.0", "gql.tada": "^1.2.0", "graphql": "^16.8.1", "superstruct": "^1.0.3", "tweetnacl": "^1.0.3" } }, "sha512-AY0wb4n6PMTRsDGygzrrTHUK/m5KwKZ4aQcN9cayiwsq2iIhfjGo7uuqMA7Y5UiqvLCoF+z7Ig14Q5qejQ/S/w=="],
-
-    "@kunalabs-io/sui-snap-wallet/@mysten/wallet-standard": ["@mysten/wallet-standard@0.10.3", "", { "dependencies": { "@mysten/sui.js": "0.50.1", "@wallet-standard/core": "1.0.3" } }, "sha512-StEMbJ7YkdjxoScmOJJjt9JaNgoRLD3FgU4LGFrKFtMXOhPu1Z4WF3qgfYBr+C3UgDh+JNiDIfN9TiGeM/Ahpw=="],
-
     "@ledgerhq/domain-service/axios": ["axios@1.12.2", "", { "dependencies": { "follow-redirects": "^1.15.6", "form-data": "^4.0.4", "proxy-from-env": "^1.1.0" } }, "sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw=="],
 
     "@ledgerhq/domain-service/react": ["react@18.3.1", "", { "dependencies": { "loose-envify": "^1.1.0" } }, "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ=="],
@@ -2867,25 +2863,23 @@
 
     "@motionone/vue/tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@mysten/bcs/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
+    "@mysten/bcs/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
-    "@mysten/sui.js/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
+    "@mysten/sui/@noble/curves": ["@noble/curves@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0" } }, "sha512-T/BoHgFXirb0ENSPBquzX0rcjXeM6Lo892a2jlYJkqk83LqZx0l1Of7DzlKJ6jkpvMrkHSnAcgb5JegL8SeIkQ=="],
 
-    "@mysten/sui.js/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
+    "@mysten/sui/@noble/hashes": ["@noble/hashes@2.2.0", "", {}, "sha512-IYqDGiTXab6FniAgnSdZwgWbomxpy9FtYvLKs7wCUs2a8RkITG+DFGO1DM9cr+E3/RgADRpFjrKVaJ1z6sjtEg=="],
 
-    "@mysten/sui.js/rpc-websockets": ["rpc-websockets@7.11.2", "", { "dependencies": { "eventemitter3": "^4.0.7", "uuid": "^8.3.2", "ws": "^8.5.0" }, "optionalDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" } }, "sha512-pL9r5N6AVHlMN/vT98+fcO+5+/UcPLf/4tq+WUaid/PPUGS/ttJ3y8e9IqmaWKtShNAysMSjkczuEA49NuV7UQ=="],
+    "@mysten/sui/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
 
-    "@mysten/sui.js/superstruct": ["superstruct@1.0.4", "", {}, "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="],
+    "@mysten/sui/@scure/bip32": ["@scure/bip32@2.2.0", "", { "dependencies": { "@noble/curves": "2.2.0", "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-zFr7t2F+a9+5tB7QbarF2HQNYrgjCNaoLAupZdKkrFMYMozJf5zqH2WJCQibMzm1qQ0QogrxVGO3qXfQDYMaQg=="],
 
-    "@mysten/wallet-adapter-base/@mysten/sui.js": ["@mysten/sui.js@0.40.0", "", { "dependencies": { "@mysten/bcs": "0.7.3", "@noble/curves": "^1.1.0", "@noble/hashes": "^1.3.1", "@open-rpc/client-js": "^1.8.1", "@scure/bip32": "^1.3.1", "@scure/bip39": "^1.2.1", "@suchipi/femver": "^1.0.0", "events": "^3.3.0", "superstruct": "^1.0.3", "tweetnacl": "^1.0.3" } }, "sha512-PEGdMe+QgpIdDIpyO4/yb+CK4x3Hki+kYPbQ5n3DVsWyb2ztFwB+5oYdc7qG3QkniO1lnCrlSHqZ5mN+x3RzrQ=="],
+    "@mysten/sui/@scure/bip39": ["@scure/bip39@2.2.0", "", { "dependencies": { "@noble/hashes": "2.2.0", "@scure/base": "2.2.0" } }, "sha512-T/Bj/YvYMNkIPq6EENO6/rcs2e7qTNuyoUXf0KBFDmp0ZDu0H2X4Lq6yC3i0c8PcWkov5EbW+yQZZbdMmk154A=="],
 
-    "@mysten/wallet-adapter-base/@mysten/wallet-standard": ["@mysten/wallet-standard@0.6.0", "", { "dependencies": { "@mysten/sui.js": "0.40.0", "@wallet-standard/core": "1.0.3" } }, "sha512-xE/OijN9zIPoTjTWuxlYMHtp7kXPcAR8dDAbxOIH5h7EZCTk+G6p+SzDp8jV5magf50VcYP0cVjS4CQLx1wQuQ=="],
+    "@mysten/utils/@scure/base": ["@scure/base@2.2.0", "", {}, "sha512-b8XEupJibegiXV+tDUseI8oLQc8ei3d/4Jkb2RpbHh3MfE054ov3uIz2dhFkB3FI8iwYkEh0gGCApkrYggkPNg=="],
+
+    "@mysten/wallet-standard/@wallet-standard/core": ["@wallet-standard/core@1.1.1", "", { "dependencies": { "@wallet-standard/app": "^1.1.0", "@wallet-standard/base": "^1.1.0", "@wallet-standard/errors": "^0.1.1", "@wallet-standard/features": "^1.1.0", "@wallet-standard/wallet": "^1.1.0" } }, "sha512-5Xmjc6+Oe0hcPfVc5n8F77NVLwx1JVAoCVgQpLyv/43/bhtIif+Gx3WUrDlaSDoM8i2kA2xd6YoFbHCxs+e0zA=="],
 
     "@noble/curves/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@open-rpc/client-js/isomorphic-ws": ["isomorphic-ws@5.0.0", "", { "peerDependencies": { "ws": "*" } }, "sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw=="],
-
-    "@open-rpc/client-js/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 
     "@osmonauts/helpers/@cosmjs/amino": ["@cosmjs/amino@0.28.13", "", { "dependencies": { "@cosmjs/crypto": "0.28.13", "@cosmjs/encoding": "0.28.13", "@cosmjs/math": "0.28.13", "@cosmjs/utils": "0.28.13" } }, "sha512-IHnH2zGwaY69qT4mVAavr/pfzx6YE+ud1NHJbvVePlbGiz68CXTi5LHR+K0lrKB5mQ7E+ZErWz2mw5U/x+V1wQ=="],
 
@@ -3116,6 +3110,10 @@
     "@types/ws/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
     "@typescript-eslint/utils/eslint-scope": ["eslint-scope@5.1.1", "", { "dependencies": { "esrecurse": "^4.3.0", "estraverse": "^4.1.1" } }, "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw=="],
+
+    "@wallet-standard/errors/chalk": ["chalk@5.6.2", "", {}, "sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA=="],
+
+    "@wallet-standard/errors/commander": ["commander@13.1.0", "", {}, "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw=="],
 
     "@walletconnect/browser-utils/@walletconnect/safe-json": ["@walletconnect/safe-json@1.0.0", "", {}, "sha512-QJzp/S/86sUAgWY6eh5MKYmSfZaRpIlmCJdi5uG4DJlKkZrHEF7ye7gA+VtbVzvTtpM/gRwO2plQuiooIeXjfg=="],
 
@@ -3581,16 +3579,6 @@
 
     "@keystonehq/sol-keyring/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/@mysten/bcs": ["@mysten/bcs@0.11.1", "", { "dependencies": { "bs58": "^5.0.0" } }, "sha512-xP85isNSYUCHd3O/g+TmZYmg4wK6cU8q/n/MebkIGP4CYVJZz2wU/G24xIZ3wI+0iTop4dfgA5kYrg/DQKCUzA=="],
-
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/bech32": ["bech32@2.0.0", "", {}, "sha512-LcknSilhIGatDAsY1ak2I8VtGaHNhgMSYVxFrGLXv+xLHytaKZKcaUJJUE7qmBr7h33o5YQwP55pMI0xmkpJwg=="],
-
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/superstruct": ["superstruct@1.0.4", "", {}, "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="],
-
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors": ["@metamask/rpc-errors@6.4.0", "", { "dependencies": { "@metamask/utils": "^9.0.0", "fast-safe-stringify": "^2.0.6" } }, "sha512-1ugFO1UoirU2esS3juZanS/Fo8C8XYocCuBpfZI5N7ECtoG+zu0wF+uWZASik6CkO6w9n/Iebt4iI4pT0vptpg=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils": ["@metamask/utils@8.5.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.0.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-I6bkduevXb72TIM9q2LRO63JSsF9EXduh3sBr9oybNX2hNNpr/j1tEjXrsG0Uabm4MJ1xkGAQEMwifvKZIkyxQ=="],
@@ -3612,20 +3600,6 @@
     "@metamask/sdk/@metamask/providers/extension-port-stream": ["extension-port-stream@3.0.0", "", { "dependencies": { "readable-stream": "^3.6.2 || ^4.4.2", "webextension-polyfill": ">=0.10.0 <1.0" } }, "sha512-an2S5quJMiy5bnZKEf6AkfH/7r8CzHvhchU40gxN+OM6HPhe7Z9T1FUychcf2M9PpPOO0Hf7BAEfJkw2TDIBDw=="],
 
     "@metamask/sdk/@metamask/providers/is-stream": ["is-stream@2.0.1", "", {}, "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg=="],
-
-    "@mysten/bcs/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
-
-    "@mysten/sui.js/rpc-websockets/eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
-
-    "@mysten/sui.js/rpc-websockets/ws": ["ws@8.18.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw=="],
-
-    "@mysten/wallet-adapter-base/@mysten/sui.js/@mysten/bcs": ["@mysten/bcs@0.7.3", "", { "dependencies": { "bs58": "^5.0.0" } }, "sha512-fbusBfsyc2MpTACi72H5edWJ670T84va+qn9jSPpb5BzZ+pzUM1Q0ApPrF5OT+mB1o5Ng+mxPQpBCZQkfiV2TA=="],
-
-    "@mysten/wallet-adapter-base/@mysten/sui.js/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
-
-    "@mysten/wallet-adapter-base/@mysten/sui.js/@scure/bip39": ["@scure/bip39@1.6.0", "", { "dependencies": { "@noble/hashes": "~1.8.0", "@scure/base": "~1.2.5" } }, "sha512-+lF0BbLiJNwVlev4eKelw1WWLaiKXw7sSl8T6FvBlWkdX+94aGJ4o8XjUdlyhTCjd8c+B3KT3JfS8P0bLRNU6A=="],
-
-    "@mysten/wallet-adapter-base/@mysten/sui.js/superstruct": ["superstruct@1.0.4", "", {}, "sha512-7JpaAoX2NGyoFlI9NBh66BQXGONc+uE+MRS5i2iOBKuS4e+ccgMDjATgZldkah+33DakBxDHiss9kvUcGAO8UQ=="],
 
     "@osmonauts/helpers/@cosmjs/amino/@cosmjs/encoding": ["@cosmjs/encoding@0.28.13", "", { "dependencies": { "base64-js": "^1.3.0", "bech32": "^1.1.4", "readonly-date": "^1.0.0" } }, "sha512-jtXbAYtV77rLHxoIrjGFsvgGjeTKttuHRv6cvuy3toCZzY7JzTclKH5O2g36IIE4lXwD9xwuhGJ2aa6A3dhNkA=="],
 
@@ -4235,8 +4209,6 @@
 
     "@injectivelabs/wallet-ts/@injectivelabs/sdk-ts/@injectivelabs/mito-proto-ts/protobufjs": ["protobufjs@7.5.4", "", { "dependencies": { "@protobufjs/aspromise": "^1.1.2", "@protobufjs/base64": "^1.1.2", "@protobufjs/codegen": "^2.0.4", "@protobufjs/eventemitter": "^1.1.0", "@protobufjs/fetch": "^1.1.0", "@protobufjs/float": "^1.0.2", "@protobufjs/inquire": "^1.1.0", "@protobufjs/path": "^1.1.2", "@protobufjs/pool": "^1.1.0", "@protobufjs/utf8": "^1.1.0", "@types/node": ">=13.7.0", "long": "^5.0.0" } }, "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg=="],
 
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/@mysten/bcs/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
-
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils": ["@metamask/utils@9.3.0", "", { "dependencies": { "@ethereumjs/tx": "^4.2.0", "@metamask/superstruct": "^3.1.0", "@noble/hashes": "^1.3.1", "@scure/base": "^1.1.3", "@types/debug": "^4.1.7", "debug": "^4.3.4", "pony-cause": "^2.1.10", "semver": "^7.5.4", "uuid": "^9.0.1" } }, "sha512-w8CVbdkDrVXFJbfBSlDfafDR6BAkpDmv1bC1UJVCoVny5tW2RKAdn9i68Xf7asYT4TnUhl/hN4zfUiKQq9II4g=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
@@ -4250,8 +4222,6 @@
     "@metamask/sdk/@metamask/providers/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
-    "@mysten/wallet-adapter-base/@mysten/sui.js/@mysten/bcs/bs58": ["bs58@5.0.0", "", { "dependencies": { "base-x": "^4.0.0" } }, "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ=="],
 
     "@osmonauts/helpers/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/json-rpc": ["@cosmjs/json-rpc@0.28.13", "", { "dependencies": { "@cosmjs/stream": "0.28.13", "xstream": "^11.14.0" } }, "sha512-fInSvg7x9P6p+GWqet+TMhrMTM3OWWdLJOGS5w2ryubMjgpR1rLiAx77MdTNkArW+/6sUwku0sN4veM4ENQu6A=="],
 
@@ -4511,8 +4481,6 @@
 
     "@injectivelabs/wallet-ts/@injectivelabs/sdk-ts/@injectivelabs/mito-proto-ts/protobufjs/@types/node": ["@types/node@22.7.5", "", { "dependencies": { "undici-types": "~6.19.2" } }, "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ=="],
 
-    "@kunalabs-io/sui-snap-wallet/@mysten/sui.js/@mysten/bcs/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
-
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/eth-json-rpc-provider/@metamask/json-rpc-engine/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
@@ -4522,8 +4490,6 @@
     "@metamask/sdk/@metamask/providers/@metamask/rpc-errors/@metamask/utils/@noble/hashes": ["@noble/hashes@1.8.0", "", {}, "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A=="],
 
     "@metamask/sdk/@metamask/providers/@metamask/rpc-errors/@metamask/utils/uuid": ["uuid@9.0.1", "", { "bin": { "uuid": "dist/bin/uuid" } }, "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="],
-
-    "@mysten/wallet-adapter-base/@mysten/sui.js/@mysten/bcs/bs58/base-x": ["base-x@4.0.1", "", {}, "sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw=="],
 
     "@osmonauts/helpers/@cosmjs/stargate/@cosmjs/tendermint-rpc/@cosmjs/socket/ws": ["ws@7.5.10", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": "^5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ=="],
 

--- a/packages/wallets/core/package.json
+++ b/packages/wallets/core/package.json
@@ -8,6 +8,7 @@
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
       "require": "./dist/cjs/index.js"
     }

--- a/packages/wallets/sui/package.json
+++ b/packages/wallets/sui/package.json
@@ -3,19 +3,20 @@
   "repository": "https://github.com/wormholelabs-xyz/wallet-aggregator-sdk/tree/master/packages/wallets/sui",
   "version": "0.0.0-auto-managed",
   "license": "MIT",
-  "main": "dist/cjs/index.js",
+  "type": "module",
+  "main": "dist/esm/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/esm/index.js",
-      "require": "./dist/cjs/index.js"
+      "default": "./dist/esm/index.js"
     }
   },
   "scripts": {
-    "build:cjs": "tsc -p tsconfig.cjs.json",
     "build:esm": "tsc -p tsconfig.esm.json",
-    "build": "shx rm -rf dist && npm run build:cjs && npm run build:esm",
+    "build": "shx rm -rf dist && npm run build:esm",
     "clean": "shx rm -rf dist",
     "prepublish": "npm run build"
   },
@@ -30,9 +31,9 @@
     "typescript": "^5.3.2"
   },
   "dependencies": {
-    "@kunalabs-io/sui-snap-wallet": "^0.4.2",
-    "@mysten/sui.js": "0.32.2",
-    "@mysten/wallet-standard": "0.5.4",
+    "@kunalabs-io/sui-snap-wallet": "^0.5.0",
+    "@mysten/sui": "^2.17.0",
+    "@mysten/wallet-standard": "^0.20.3",
     "@wormhole-labs/wallet-aggregator-core": "workspace:^"
   }
 }

--- a/packages/wallets/sui/src/sui.ts
+++ b/packages/wallets/sui/src/sui.ts
@@ -1,21 +1,17 @@
-import {
-  Connection,
-  ExecuteTransactionRequestType,
-  JsonRpcProvider,
-  SuiTransactionBlockResponseOptions,
-  TransactionBlock,
-} from "@mysten/sui.js";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
+import { Transaction } from "@mysten/sui/transactions";
+import { fromBase64 } from "@mysten/sui/utils";
 import {
   StandardConnectMethod,
   StandardDisconnectMethod,
   Wallet as StandardWallet,
-  SuiSignAndExecuteTransactionBlockMethod,
-  SuiSignAndExecuteTransactionBlockOutput,
+  SignedTransaction,
+  SuiSignAndExecuteTransactionMethod,
+  SuiSignAndExecuteTransactionOutput,
   SuiSignMessageInput,
   SuiSignMessageMethod,
   SuiSignMessageOutput,
-  SuiSignTransactionBlockMethod,
-  SuiSignTransactionBlockOutput,
+  SuiSignTransactionMethod,
   WalletAccount,
 } from "@mysten/wallet-standard";
 import {
@@ -26,7 +22,6 @@ import {
   NotSupported,
   SendTransactionResult,
   Wallet,
-  WalletEvents,
 } from "@wormhole-labs/wallet-aggregator-core";
 import { DEFAULTS, SuiWalletName, WalletInfo } from "./walletsInfo";
 
@@ -34,24 +29,22 @@ export enum FeatureName {
   STANDARD__CONNECT = "standard:connect",
   STANDARD__DISCONNECT = "standard:disconnect",
   STANDARD__EVENTS = "standard:events",
-  SUI__SIGN_AND_EXECUTE_TRANSACTION_BLOCK = "sui:signAndExecuteTransactionBlock",
-  SUI__SIGN_TRANSACTION_BLOCK = "sui:signTransactionBlock",
+  SUI__SIGN_AND_EXECUTE_TRANSACTION = "sui:signAndExecuteTransaction",
+  SUI__SIGN_TRANSACTION = "sui:signTransaction",
   SUI__SIGN_MESSAGE = "sui:signMessage",
 }
 
 interface SignAndSendTransactionOptions {
-  transactionBlock: TransactionBlock;
-  requestType?: ExecuteTransactionRequestType;
-  options?: SuiTransactionBlockResponseOptions;
+  transaction: Transaction;
 }
 
 type ConnectFeature = { connect: StandardConnectMethod };
 type DisconnectFeature = { disconnect: StandardDisconnectMethod };
-type SignAndExecuteTransactionBlockFeature = {
-  signAndExecuteTransactionBlock: SuiSignAndExecuteTransactionBlockMethod;
+type SignAndExecuteTransactionFeature = {
+  signAndExecuteTransaction: SuiSignAndExecuteTransactionMethod;
 };
-type SignTransactionBlockFeature = {
-  signTransactionBlock: SuiSignTransactionBlockMethod;
+type SignTransactionFeature = {
+  signTransaction: SuiSignTransactionMethod;
 };
 type SignMessageFeature = { signMessage: SuiSignMessageMethod };
 type SuiNetworkInfo = {
@@ -63,12 +56,12 @@ const DO_NOT_REMOVE_WALLET_FROM = ["OKX", "Bitget"] as const;
 export class SuiWallet extends Wallet<
   typeof CHAIN_ID_SUI,
   void,
-  TransactionBlock,
-  SuiSignTransactionBlockOutput,
-  SuiSignTransactionBlockOutput,
-  SuiSignAndExecuteTransactionBlockOutput,
+  Transaction,
+  SignedTransaction,
+  SignedTransaction,
+  SuiSignAndExecuteTransactionOutput,
   SignAndSendTransactionOptions,
-  SuiSignAndExecuteTransactionBlockOutput,
+  SuiSignAndExecuteTransactionOutput,
   SuiSignMessageInput,
   SuiSignMessageOutput,
   SuiNetworkInfo,
@@ -80,7 +73,10 @@ export class SuiWallet extends Wallet<
 
   constructor(
     private readonly wallet: StandardWallet,
-    private readonly connection?: Connection
+    // v2 Sui gRPC client, used to submit a separately-signed transaction
+    // (sendTransaction). Optional: wallets using signAndSendTransaction
+    // submit via the wallet itself and don't need it.
+    private readonly client?: SuiGrpcClient
   ) {
     super();
     if (DO_NOT_REMOVE_WALLET_FROM.find((name) => wallet.name.includes(name))) {
@@ -120,52 +116,50 @@ export class SuiWallet extends Wallet<
     this.emit("disconnect");
   }
 
-  signTransaction(
-    transactionBlock: TransactionBlock
-  ): Promise<SuiSignTransactionBlockOutput> {
+  signTransaction(transaction: Transaction): Promise<SignedTransaction> {
     if (!this.activeAccount) throw new NotConnected();
 
-    const { signTransactionBlock } =
-      this.getFeature<SignTransactionBlockFeature>(
-        FeatureName.SUI__SIGN_TRANSACTION_BLOCK
-      );
+    const { signTransaction } = this.getFeature<SignTransactionFeature>(
+      FeatureName.SUI__SIGN_TRANSACTION
+    );
 
-    return signTransactionBlock({
-      transactionBlock,
+    return signTransaction({
+      transaction,
       account: this.activeAccount,
       chain: this.activeAccount.chains[0],
     });
   }
 
   async sendTransaction(
-    tx: SuiSignTransactionBlockOutput
-  ): Promise<SendTransactionResult<SuiSignAndExecuteTransactionBlockOutput>> {
-    if (!this.connection) throw new Error("Connection not provided");
-    const provider = new JsonRpcProvider(this.connection);
+    tx: SignedTransaction
+  ): Promise<SendTransactionResult<SuiSignAndExecuteTransactionOutput>> {
+    if (!this.client) throw new Error("Sui client not provided");
 
-    const result = await provider.executeTransactionBlock({
-      signature: tx.signature,
-      transactionBlock: tx.transactionBlockBytes,
+    const result = await this.client.executeTransaction({
+      transaction: fromBase64(tx.bytes),
+      signatures: [tx.signature],
     });
 
+    const executed = result.Transaction ?? result.FailedTransaction;
+
     return {
-      id: result.digest,
-      data: result,
+      id: executed!.digest,
+      data: result as unknown as SuiSignAndExecuteTransactionOutput,
     };
   }
 
   async signAndSendTransaction(
     options: SignAndSendTransactionOptions
-  ): Promise<SendTransactionResult<SuiSignAndExecuteTransactionBlockOutput>> {
+  ): Promise<SendTransactionResult<SuiSignAndExecuteTransactionOutput>> {
     if (!this.activeAccount) throw new NotConnected();
 
-    const { signAndExecuteTransactionBlock } =
-      this.getFeature<SignAndExecuteTransactionBlockFeature>(
-        FeatureName.SUI__SIGN_AND_EXECUTE_TRANSACTION_BLOCK
+    const { signAndExecuteTransaction } =
+      this.getFeature<SignAndExecuteTransactionFeature>(
+        FeatureName.SUI__SIGN_AND_EXECUTE_TRANSACTION
       );
 
-    const result = await signAndExecuteTransactionBlock({
-      ...options,
+    const result = await signAndExecuteTransaction({
+      transaction: options.transaction,
       account: this.activeAccount,
       chain: this.activeAccount.chains[0],
     });
@@ -238,12 +232,10 @@ export class SuiWallet extends Wallet<
 
   getFeatures(): BaseFeatures[] {
     const features = [BaseFeatures.SendTransaction];
-    if (this.wallet.features[FeatureName.SUI__SIGN_TRANSACTION_BLOCK]) {
+    if (this.wallet.features[FeatureName.SUI__SIGN_TRANSACTION]) {
       features.push(BaseFeatures.SignTransaction);
     }
-    if (
-      this.wallet.features[FeatureName.SUI__SIGN_AND_EXECUTE_TRANSACTION_BLOCK]
-    ) {
+    if (this.wallet.features[FeatureName.SUI__SIGN_AND_EXECUTE_TRANSACTION]) {
       features.push(BaseFeatures.SignAndSendTransaction);
     }
     if (this.wallet.features[FeatureName.SUI__SIGN_MESSAGE]) {

--- a/packages/wallets/sui/src/utils.ts
+++ b/packages/wallets/sui/src/utils.ts
@@ -1,4 +1,4 @@
-import { Connection } from "@mysten/sui.js";
+import { SuiGrpcClient } from "@mysten/sui/grpc";
 import {
   Wallet as StandardWallet,
   Wallets,
@@ -9,8 +9,8 @@ import { SuiWallet } from "./sui";
 const WALLET_DETECT_TIMEOUT = 250;
 
 interface GetReadyWalletsOptions {
-  /** SUI connection */
-  connection?: Connection;
+  /** Sui gRPC client (for submitting separately-signed transactions) */
+  client?: SuiGrpcClient;
 }
 interface GetWalletsOptions extends GetReadyWalletsOptions {
   timeout?: number;
@@ -36,7 +36,7 @@ export const getReadyWallets = (
   return wallets
     .get()
     .filter(supportsSui)
-    .map((w: StandardWallet) => new SuiWallet(w, options.connection));
+    .map((w: StandardWallet) => new SuiWallet(w, options.client));
 };
 
 /**
@@ -47,7 +47,7 @@ export const getReadyWallets = (
 export const getWallets = async (
   options: GetWalletsOptions = {}
 ): Promise<SuiWallet[]> => {
-  const { timeout = WALLET_DETECT_TIMEOUT, connection } = options;
+  const { timeout = WALLET_DETECT_TIMEOUT, client } = options;
   const detector: Wallets = getSuiWallets();
 
   const wallets: StandardWallet[] = [...detector.get()];
@@ -58,7 +58,7 @@ export const getWallets = async (
       setTimeout(() => {
         if (removeListener) removeListener();
         resolve(
-          wallets.filter(supportsSui).map((w) => new SuiWallet(w, connection))
+          wallets.filter(supportsSui).map((w) => new SuiWallet(w, client))
         );
       }, timeout);
 

--- a/packages/wallets/sui/tsconfig.cjs.json
+++ b/packages/wallets/sui/tsconfig.cjs.json
@@ -1,7 +1,0 @@
-{
-  "extends": "../../../tsconfig.cjs.json",
-  "include": ["src"],
-  "compilerOptions": {
-    "outDir": "./dist/cjs"
-  }
-}

--- a/packages/wallets/sui/tsconfig.esm.json
+++ b/packages/wallets/sui/tsconfig.esm.json
@@ -3,6 +3,8 @@
   "include": ["src"],
   "compilerOptions": {
     "outDir": "./dist/esm",
-    "declarationDir": "./dist/types"
+    "declarationDir": "./dist/types",
+    "module": "esnext",
+    "moduleResolution": "bundler"
   }
 }

--- a/packages/wallets/sui/tsconfig.json
+++ b/packages/wallets/sui/tsconfig.json
@@ -1,7 +1,4 @@
 {
   "extends": "../../../tsconfig.root.json",
-  "references": [
-    { "path": "./tsconfig.cjs.json" },
-    { "path": "./tsconfig.esm.json" }
-  ]
+  "references": [{ "path": "./tsconfig.esm.json" }]
 }

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -10,6 +10,7 @@
     "noEmitOnError": true,
     "resolveJsonModule": true,
     "strict": true,
-    "stripInternal": true
+    "stripInternal": true,
+    "skipLibCheck": true
   }
 }


### PR DESCRIPTION
Migrate @wormhole-labs/wallet-aggregator-sui off the deprecated @mysten/sui.js@0.32 (JSON-RPC) to @mysten/sui@^2.17 (gRPC) and modern @mysten/wallet-standard@^0.20.

- TransactionBlock -> Transaction; signTransactionBlock/ signAndExecuteTransactionBlock -> signTransaction/signAndExecuteTransaction; JsonRpcProvider.executeTransactionBlock -> SuiGrpcClient.executeTransaction
- constructor connection: Connection -> client: SuiGrpcClient (breaking)
- @kunalabs-io/sui-snap-wallet ^0.4.2 -> ^0.5.0 (v2-compatible)
- ESM-only packaging (v2 is ESM-only): type=module, drop cjs build
- skipLibCheck (v2 pulls @types/web conflicting with lib.dom) and a types condition on wallet-aggregator-core's exports (for bundler resolution)