### PR TITLE
fix: align action version comments with pinned SHAs (zizmor)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,7 +16,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
         with:
           persist-credentials: false
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,13 +12,13 @@ jobs:
       id-token: write # Required for OIDC authentication with npm
 
     steps:
-      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           persist-credentials: false
       - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.1
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"


### PR DESCRIPTION
## Summary

CI is failing on the zizmor `ref-version-mismatch` audit: three pinned actions had version comments naming a major tag (`# v3`, `# v5`, `# v6`) that points to a different commit than the pinned SHA. This updates the comments to the exact release tags the SHAs resolve to (verified against the GitHub API):

- `build.yml`: `actions/checkout` → `# v3.6.0`
- `publish.yml`: `actions/checkout` → `# v5.0.1`
- `publish.yml`: `actions/setup-node` → `# v6.4.0`

No SHA changes — comments only, so workflow behavior is unchanged.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/wormholelabs-xyz/codesmith/wallet-aggregator-sdk/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787837222&installation_model_id=15502&pr_number=42&repository=wormholelabs-xyz%2Fwallet-aggregator-sdk&return_to=https%3A%2F%2Fgithub.com%2Fwormholelabs-xyz%2Fwallet-aggregator-sdk%2Fpull%2F42&signature=8bbd050f335d12cf1b589bfb6a4e29898ca537e983f03731460f4808fbe2be64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->